### PR TITLE
feat: exclude guest users

### DIFF
--- a/Invoke-EntraAuthReport.ps1
+++ b/Invoke-EntraAuthReport.ps1
@@ -1502,7 +1502,7 @@ Function Generate-EntraAuthReport {
 "@
 
     # Generate the path
-    $OutputPath = "$outpath\Entra_Authentication_Methods_Report.html"
+    $OutputPath = Join-Path -Path $outpath -ChildPath "Entra_Authentication_Methods_Report.html"
 
     # Output HTML report
     $html | Out-File -FilePath $OutputPath -Encoding UTF8

--- a/Invoke-EntraAuthReport.ps1
+++ b/Invoke-EntraAuthReport.ps1
@@ -155,12 +155,11 @@ Function Get-UserRegistrationDetails {
     }
 
     $usersWithMobileMethods = $userRegistrations | Where-Object { $_.methodsRegistered -contains "mobilePhone" } | Select-Object id, userPrincipalName, methodsRegistered
-    $userRegistrationsMethods = [System.Collections.Generic.List[Object]]::new()
     
     Foreach ($user in $usersWithMobileMethods) {
-        $methodsFromReport = ($userRegistrations | where { $_.userPrincipalName -eq $user.userPrincipalName }).methodsRegistered
+        $methodsFromReport = ($userRegistrations | Where-Object { $_.userPrincipalName -eq $user.userPrincipalName }).methodsRegistered
         $methodsToReplace = @()
-        $methodsToReplace += $methodsFromReport | where { $_ -ne "mobilePhone" }
+        $methodsToReplace += $methodsFromReport | Where-Object { $_ -ne "mobilePhone" }
         $methodsToReplace += "Voice Call"  
         
         if (-not $skipDetailedPhoneInfo) {
@@ -170,7 +169,7 @@ Function Get-UserRegistrationDetails {
             }
         }
     
-        ($userRegistrations | where { $_.userPrincipalName -eq $user.userPrincipalName }).methodsRegistered = $methodsToReplace
+        ($userRegistrations | Where-Object { $_.userPrincipalName -eq $user.userPrincipalName }).methodsRegistered = $methodsToReplace
     }
 
     return $userRegistrations

--- a/Invoke-EntraAuthReport.ps1
+++ b/Invoke-EntraAuthReport.ps1
@@ -210,8 +210,10 @@ $weakMethodTypes = $AllMethods | Where-Object { $_.Strength -eq 'Weak' }
 
 ###Get authentication methods info
 #Get user registration details
+Write-output "Fetching users registration details..."
 $userRegistrationsReport = Get-UserRegistrationDetails
 #Get authentication methods
+Write-output "Fetching authentication methods..."
 $authenticationMethods = Get-AuthenticationMethods
 #Get disabled and enabled authentication methods
 $disabledAuthenticationMethods = $authenticationMethods | where { $_.State -eq "Disabled" }
@@ -227,6 +229,7 @@ $enabledWeakAuthenticationMethods = $MethodsEnabledByPolicy | where { $_.Strengt
 $totalUsersCount = $userRegistrationsReport.Count
 
 ### Calculate MFA capable info
+Write-output "Analyzing MFA info..."
 $totalMFACapableUsers = $userRegistrationsReport | where { $_.isMfaCapable -eq $true }
 $totalMFACapableUsersCount = $totalMFACapableUsers.Count
 #Calculate percentage of MFA capable users
@@ -236,6 +239,7 @@ if ($totalUsersCount -gt 0) {
 }
 
 ###Calculate passwordless info
+Write-output "Analyzing passwordless info..."
 $totalPasswordlessUsers = $userRegistrationsReport | where { $_.isPasswordlessCapable -eq $true }
 $totalPasswordlessUsersCount = $totalPasswordlessUsers.Count
 #Calculate percentage of passwordless capable users
@@ -246,6 +250,7 @@ if ($totalUsersCount -gt 0) {
 
 ###Calculate strong authentication method info
 # Filter users who have registered strong authentication methods
+Write-output "Analyzing users who have registered strong authentication methods..."
 $usersWithStrongMethods = $userRegistrationsReport | Where-Object {
     $user = $_
     # Check if any of the user's registered methods are in the strongMethodTypes list
@@ -267,6 +272,7 @@ if ($totalUsersCount -gt 0) {
 
 ###Calculate weak authentication method info
 # Filter users who have ONLY weak authentication methods registered
+Write-output "Analyzing users who have ONLY weak authentication methods registered..."
 $usersWithWeakMethods = $userRegistrationsReport | Where-Object {
     $user = $_
     # Check if any of the user's registered methods are in the weakMethodTypes list
@@ -281,6 +287,7 @@ $usersWithWeakMethods = $userRegistrationsReport | Where-Object {
 }
 
 ###Calculate users with both strong AND weak methods
+Write-output "Analyzing users with both strong AND weak methods..."
 $usersWithBothMethodTypes = $usersWithStrongMethods | Where-Object {
     $user = $_
     # Check if this user is also in the weak methods list by comparing UPN
@@ -294,6 +301,7 @@ if ($totalUsersCount -gt 0) {
 }
 
 ### Calculate privileged users not using phish resistant methods methods
+Write-output "Analyzing privileged users not using phish resistant methods..."
 $PrivilegedUsersRegistrationDetails = Get-PrivilegedUserRegistrationDetails -userRegistrations $userRegistrationsReport
 $PrivilegedUsersNotUsingPhishResistantMethods = $PrivilegedUsersRegistrationDetails | where { $_.methodsRegistered -notcontains "fido2SecurityKey" -and $_.methodsRegistered -notcontains "passKeyDeviceBound" -and $_.methodsRegistered -notcontains "passKeyDeviceBoundAuthenticator" }
 # Count of privileged users not using phish resistant methods
@@ -1515,4 +1523,5 @@ Function Generate-EntraAuthReport {
 }
 
 # Generate the report
+Write-output "Generating HTML report..."
 Generate-EntraAuthReport -UserRegistrations $userRegistrationsReport -MethodTypes $AllMethods -OutputPath $OutputPath

--- a/Invoke-EntraAuthReport.ps1
+++ b/Invoke-EntraAuthReport.ps1
@@ -163,7 +163,7 @@ Function Get-UserRegistrationDetails {
         $methodsToReplace += $methodsFromReport | where { $_ -ne "mobilePhone" }
         $methodsToReplace += "Voice Call"  
         
-        if (-not kipDetailedPhoneInfo) {
+        if (-not $skipDetailedPhoneInfo) {
             $Methods = Invoke-MgGraphRequest -uri "/beta/users/$($user.id)/authentication/methods" -OutputType PSObject | WHere { $_."@odata.type" -eq '#microsoft.graph.phoneAuthenticationMethod'}
             if ($Methods.smsSignInState -eq "ready") { 
                 $methodsToReplace += "SMS" 

--- a/Invoke-EntraAuthReport.ps1
+++ b/Invoke-EntraAuthReport.ps1
@@ -321,7 +321,9 @@ Function Generate-EntraAuthReport {
     )
     
     # Create HTML header
-    $html = @"
+    $html = [System.Text.StringBuilder]::new()
+
+    [void]$html.AppendLine(@"
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1018,7 +1020,7 @@ Function Generate-EntraAuthReport {
                         <th style="width: 7%;">Default Method</th>
                         <th style="width: 5%;">MFA</th>
                         <th style="width: 5%;">Pless</th>
-"@
+"@)
 
     # Add column for each method type
     foreach ($method in $MethodTypes) {
@@ -1028,18 +1030,18 @@ Function Generate-EntraAuthReport {
         $isDisabled = $MethodsDisabledByPolicy.Name -contains $method.Name
         
         if ($isDisabled) {
-            $html += "                    <th class=`"$cssClass diagonal-header`" data-disabled=`"true`"><div>$($method.Name)</div></th>`n"
+            [void]$html.AppendLine("                    <th class=`"$cssClass diagonal-header`" data-disabled=`"true`"><div>$($method.Name)</div></th>`n")
         }
         else {
-            $html += "                    <th class=`"$cssClass diagonal-header`" ><div>$($method.Name)</div></th>`n"
+            [void]$html.AppendLine("                    <th class=`"$cssClass diagonal-header`" ><div>$($method.Name)</div></th>`n")
         }
     }
 
-    $html += @"
+    [void]$html.AppendLine(@"
                 </tr>
             </thead>
             <tbody>
-"@
+"@)
 
     # Add a row for each user
     foreach ($user in $UserRegistrations) {
@@ -1080,22 +1082,22 @@ Function Generate-EntraAuthReport {
         if ($isPrivileged) { $dataAttributes += "data-privileged='true' " }
         if ($isSyncUser) { $dataAttributes += "data-syncuser='true' " }
         
-        $html += "                <tr $dataAttributes>`n"
-        $html += "                    <td>$($user.userPrincipalName)</td>`n"
-        $html += "                    <td>$($user.defaultmfaMethod)</td>`n"
-        $html += "                    <td>$(if($user.isMfaCapable) {"<span class='checkmark'>✓</span>"} else {"<span class='x-mark'>✗</span>"})</td>`n"
-        $html += "                    <td>$(if($user.isPasswordlessCapable) {"<span class='checkmark'>✓</span>"} else {"<span class='x-mark'>✗</span>"})</td>`n"
+        [void]$html.AppendLine("                <tr $dataAttributes>`n")
+        [void]$html.AppendLine("                    <td>$($user.userPrincipalName)</td>`n")
+        [void]$html.AppendLine("                    <td>$($user.defaultmfaMethod)</td>`n")
+        [void]$html.AppendLine("                    <td>$(if($user.isMfaCapable) {"<span class='checkmark'>✓</span>"} else {"<span class='x-mark'>✗</span>"})</td>`n")
+        [void]$html.AppendLine("                    <td>$(if($user.isPasswordlessCapable) {"<span class='checkmark'>✓</span>"} else {"<span class='x-mark'>✗</span>"})</td>`n")
         
         # Add column for each method type - check if registered
         foreach ($method in $MethodTypes) {
             $isRegistered = $userMethods -contains $method.type
-            $html += "                    <td>$(if($isRegistered) {"<span class='checkmark'>✓</span>"} else {"<span class='x-mark'>✗</span>"})</td>`n"
+            [void]$html.AppendLine("                    <td>$(if($isRegistered) {"<span class='checkmark'>✓</span>"} else {"<span class='x-mark'>✗</span>"})</td>`n")
         }
         
-        $html += "                </tr>`n"
+        [void]$html.AppendLine("                </tr>`n")
     }
 
-    $html += @"
+    [void]$html.AppendLine(@"
             </tbody>
         </table>
     </div>
@@ -1507,13 +1509,13 @@ Function Generate-EntraAuthReport {
     </script>
 </body>
 </html>
-"@
+"@)
 
     # Generate the path
     $OutputPath = Join-Path -Path $outpath -ChildPath "Entra_Authentication_Methods_Report.html"
 
     # Output HTML report
-    $html | Out-File -FilePath $OutputPath -Encoding UTF8
+    $html.ToString() | Out-File -FilePath $OutputPath -Encoding UTF8
     Write-output "HTML report generated at $OutputPath"
     
     # Open the report in the default browser

--- a/Invoke-EntraAuthReport.ps1
+++ b/Invoke-EntraAuthReport.ps1
@@ -148,10 +148,10 @@ Function Get-UserRegistrationDetails {
         $userRegistrations = $userRegistrations | Where-Object { $_.userType -ne "guest" }
     }
 
-    $usersWithMobileMethods = $userRegistrations | where { $_.methodsRegistered -contains "mobilePhone" } | Select userPrincipalName, methodsRegistered
+    $usersWithMobileMethods = $userRegistrations | where { $_.methodsRegistered -contains "mobilePhone" } | Select id, userPrincipalName, methodsRegistered
     $userRegistrationsMethods = [System.Collections.Generic.List[Object]]::new()
     Foreach ($user in $usersWithMobileMethods) {
-        $Methods = Invoke-MgGraphRequest -uri "/beta/users/$($user.userPrincipalName)/authentication/methods" -OutputType PSObject | WHere { $_."@odata.type" -eq '#microsoft.graph.phoneAuthenticationMethod' }
+        $Methods = Invoke-MgGraphRequest -uri "/beta/users/$($user.id)/authentication/methods" -OutputType PSObject | WHere { $_."@odata.type" -eq '#microsoft.graph.phoneAuthenticationMethod' }
         if ($Methods.smsSignInState -eq "ready") { $phoneinfo = @("Voice Call", "SMS") }else { $phoneinfo = @("Voice Call") }
         $methodsFromReport = ($userRegistrations | where { $_.userPrincipalName -eq $user.userPrincipalName }).methodsRegistered
         $methodsToReplace = @()


### PR DESCRIPTION
Hi, I started using your tool and wanted to suggest some of the improvements I’ve been trying on my end, if you’re interested.

Added new parameters:
- limit: Defines how many userRegistrationDetails records to fetch.
- skipGuest: Skips all the users of type 'guest’.
- skipDetailedPhoneInfo: Skips the request for detailed Mobile authentication methods.
   note: on high number of users those call are simply taking too much
- openBrowser: If true, opens the generated report in the browser.

(Happy to put better names if you have suggestions.)

Performance:
- now using StringBuilder for the HTML report instead of string concatenation reducing the execution time ~90%.
  I’m using the script with around 6k users and the time to generate the report went from 20 mins to 2.

Compatibility:
- now using Join-Path to join the output folder with the report name instead of the hardcoded “\” char to guarantee cross-platform compatibility (i.e. using powershell in some linux-based CI/CD environment)

Sorry for the formatting-related changes, I can revert them if they disturb you or even better if you could pass me your settings I can stick to them, thanks.

Thanks for providing the tool!